### PR TITLE
Locking in "next" version 12.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@mui/material": "^5.6.3",
     "@mui/styled-engine-sc": "^5.6.1",
     "@mui/x-data-grid": "^5.10.0",
-    "next": "^12.1.6",
+    "next": "12.1.6",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "styled-components": "^5.3.5"


### PR DESCRIPTION
next.js has a bug in the new version 12.3 released 1 week ago that breaks inside loop variables.